### PR TITLE
Plat line ebf recipe fix

### DIFF
--- a/src/main/java/gtb/common/metatileentities/multiblocks/MetaTileEntityNeutronAccelerator.java
+++ b/src/main/java/gtb/common/metatileentities/multiblocks/MetaTileEntityNeutronAccelerator.java
@@ -1,6 +1,5 @@
 package gtb.common.metatileentities.multiblocks;
 
-import gregtech.common.blocks.BlockMetalCasing;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.ResourceLocation;
@@ -22,6 +21,7 @@ import gregtech.api.util.RelativeDirection;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.common.blocks.BlockBoilerCasing.BoilerCasingType;
+import gregtech.common.blocks.BlockMetalCasing;
 import gregtech.common.blocks.MetaBlocks;
 
 import codechicken.lib.render.CCRenderState;
@@ -39,14 +39,15 @@ public class MetaTileEntityNeutronAccelerator extends RecipeMapMultiblockControl
     public IBlockState getCasingState() {
         return MetaBlocks.METAL_CASING.getState(BlockMetalCasing.MetalCasingType.STAINLESS_CLEAN);
     }
+
     @Override
     protected @NotNull BlockPattern createStructurePattern() {
         return FactoryBlockPattern.start(RelativeDirection.RIGHT, RelativeDirection.BACK, RelativeDirection.UP)
-                .aisle("CNMNC","CCCCC","CCCCC","CCCCC","CCSCC")
-                .aisle("F~~~F","~~~~~","~~P~~","~~~~~","F~~~F")
-                .aisle("F~~~F","~~~~~","~~P~~","~~~~~","F~~~F")
-                .aisle("F~~~F","~~~~~","~~P~~","~~~~~","F~~~F")
-                .aisle("CCCCC","CCCCC","CCCCC","CCCCC","CCCCC")
+                .aisle("CNMNC", "CCCCC", "CCCCC", "CCCCC", "CCSCC")
+                .aisle("F~~~F", "~~~~~", "~~P~~", "~~~~~", "F~~~F")
+                .aisle("F~~~F", "~~~~~", "~~P~~", "~~~~~", "F~~~F")
+                .aisle("F~~~F", "~~~~~", "~~P~~", "~~~~~", "F~~~F")
+                .aisle("CCCCC", "CCCCC", "CCCCC", "CCCCC", "CCCCC")
                 .where('S', selfPredicate())
                 .where('~', any())
                 .where('W', states(getCasingState())

--- a/src/main/java/gtb/loaders/recipe/GTBRecipeLoader.java
+++ b/src/main/java/gtb/loaders/recipe/GTBRecipeLoader.java
@@ -3,12 +3,14 @@ package gtb.loaders.recipe;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.unification.material.Materials;
+
 import gtb.api.recipes.GTBRecipeMaps;
 
 public final class GTBRecipeLoader {
 
     public static void init() {
         RecipeMaps.BLAST_RECIPES.setMaxInputs(4);
+        RecipeMaps.BLAST_RECIPES.setMaxFluidInputs(2);
         RecipeMaps.CENTRIFUGE_RECIPES.setMaxFluidInputs(2);
         RecipeMaps.CENTRIFUGE_RECIPES.setSlotOverlay(false, true, false, GuiTextures.CENTRIFUGE_OVERLAY);
 


### PR DESCRIPTION
This PR fixes this recipe being invalid because of lower maxFluidInputs value in GTCEu :

```java
        RecipeMaps.BLAST_RECIPES.recipeBuilder()
                .fluidInputs(Materials.Oxygen.getFluid(3000))
                .input(dust, Materials.SodaAsh, 18)
                .input(dust, GTBMaterials.LeachResidue, 40)
                .output(dust, GTBMaterials.SodiumRuthenate, 21)
                .output(dust, Materials.RarestMetalMixture, 6)
                .fluidInputs(Materials.CarbonMonoxide.getFluid(3000))
                .EUt(120).duration(600).blastFurnaceTemp(775)
                .buildAndRegister();
  ```

by adding 
```java 
RecipeMaps.BLAST_RECIPES.setMaxFluidInputs(2);
```
  to the `GTBRecipeLoader`class.        